### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
 		<!-- android -->
 		<platform name="android">
 			<config-file target="res/xml/config.xml" parent="/*">
-				<feature name="SMSPlugin">
+				<feature name="SmsPlugin">
 					<param name="android-package" value="info.asankan.phonegap.smsplugin.SmsPlugin" />
 				</feature>
 			</config-file>


### PR DESCRIPTION
Fixes bug that throws "Class not found" error. Feature name on line 18 is case sensitive and didn't match the name referenced in the JavaScript. Would be great to get this fix merged into the main branch for the benefit of PhoneGap Build users!
